### PR TITLE
update types for tagIds and userId fields

### DIFF
--- a/typings/models/Order.d.ts
+++ b/typings/models/Order.d.ts
@@ -43,8 +43,8 @@ export interface IOrder {
     insuranceOptions: IInsuranceOptions;
     internationalOptions: IInternationalOptions;
     advancedOptions: IAdvancedOptions;
-    tagIds: number[];
-    userId: string;
+    tagIds?: number[];
+    userId?: string;
     externallyFulfilled: boolean;
     externallyFulfilledBy: string;
     labelMessages?: string;


### PR DESCRIPTION
These 2 fields seem to have the possibility of being null. This updates the interface with an expectation of them not being available but they should really be documented as possibly being null. For now though since the rest of the interface(s) do not reflect the fact that some fields are actually null instead of undefined, I've left these 2 fields as possibly undefined as well.